### PR TITLE
A Regex matcher for openmediavaul-webgui

### DIFF
--- a/etc/fail2ban/filter.d/openmediavault-webgui.conf
+++ b/etc/fail2ban/filter.d/openmediavault-webgui.conf
@@ -1,0 +1,3 @@
+[Definition]
+failregex = openmediavault-webgui\[.*\]: Unauthorized login attempt from <HOST> \[username=.*, user-agent=.*]
+ignoreregex =


### PR DESCRIPTION
This matches failed authentications in /var/log/auth.log
