### PR TITLE
fix action type in omv config builder script conf.service.fail2ban.sh

### DIFF
--- a/usr/share/openmediavault/confdb/create.d/conf.service.fail2ban.sh
+++ b/usr/share/openmediavault/confdb/create.d/conf.service.fail2ban.sh
@@ -34,7 +34,7 @@ if ! omv_config_exists "${SERVICE_XPATH}"; then
     omv_config_add_key "${SERVICE_XPATH}" "bantime" "604800"
     omv_config_add_key "${SERVICE_XPATH}" "maxretry" "3"
     omv_config_add_key "${SERVICE_XPATH}" "destemail" "root@localhost"
-    omv_config_add_node "${SERVICE_XPATH}" "action" "action_mwl"
+    omv_config_add_key "${SERVICE_XPATH}" "action" "action_mwl"
     omv_config_add_node "${SERVICE_XPATH}" "jails"
 fi
 


### PR DESCRIPTION
The correct config type is **key** not **node**

removed :   omv_config_add_node "${SERVICE_XPATH}" "action" "action_mwl"
added     :   omv_config_add_key "${SERVICE_XPATH}" "action" "action_mwl"


Best