### PR TITLE
fix ssh-ddos jail configuration

### DIFF
--- a/usr/share/openmediavault/confdb/create.d/conf.service.fail2ban.sh
+++ b/usr/share/openmediavault/confdb/create.d/conf.service.fail2ban.sh
@@ -53,11 +53,11 @@ if ! omv_config_exists "${SERVICE_XPATH}/jails/jail[uuid='36b96e6c-9187-4b93-b0c
  if ! omv_config_exists "${SERVICE_XPATH}/jails/jail[uuid='59650e01-5e07-4076-9b15-ce352f4b4356']"; then
      object="<uuid>59650e01-5e07-4076-9b15-ce352f4b4356</uuid>"
      object="${object}<enable>0</enable>"
-     object="${object}<name>ssh-ddos</name>"
+     object="${object}<name>sshd-ddos</name>"
      object="${object}<port>ssh</port>"
      object="${object}<maxretry>3</maxretry>"
      object="${object}<bantime>-1</bantime>"
-     object="${object}<filter>sshd-ddos</filter>"
+     object="${object}<filter>sshd</filter>"
      object="${object}<logpath>/var/log/auth.log</logpath>"
      omv_config_add_node_data "${SERVICE_XPATH}/jails" "jail" "${object}"
  fi


### PR DESCRIPTION
The section should be named `[sshd-ddos]`, and the filter should be `sshd` rather than `sshd-ddos`.

There's a similar issue with the `apache-404` filter, but I'm not sure what filter should be used there.

> 2022-02-26 17:01:23,486 fail2ban.configreader   [2385714]: ERROR   Found no accessible config files for 'filter.d/sshd-ddos' under /etc/fail2ban
> 2022-02-26 17:01:23,486 fail2ban.jailreader     [2385714]: ERROR   Unable to read the filter 'sshd-ddos'
> 2022-02-26 17:01:23,486 fail2ban.jailsreader    [2385714]: ERROR   Errors in jail 'ssh-ddos'. Skipping...
> 2022-02-26 17:01:23,499 fail2ban.configreader   [2385714]: ERROR   Found no accessible config files for 'filter.d/apache-404' under /etc/fail2ban
> 2022-02-26 17:01:23,499 fail2ban.jailreader     [2385714]: ERROR   Unable to read the filter 'apache-404'
> 2022-02-26 17:01:23,499 fail2ban.jailsreader    [2385714]: ERROR   Errors in jail 'apache-404'. Skipping...