### PR TITLE
Add Samba filter and jail into Fail2Ban

### DIFF
--- a/etc/fail2ban/filter.d/samba.conf
+++ b/etc/fail2ban/filter.d/samba.conf
@@ -1,2 +1,33 @@
+# Fail2Ban filter for samba
+#
+# This filter is only tested on OpenMediaVault 7.
+#
+# If you want to protect Samba from being bruteforced by password
+# authentication then setup Fail2Ban with this filter to protect the
+# Samba protocol before it is too late! 
+#
+# By default OMV's Samba does not log any authotization or 
+# authentication activities which is required to be monitored by
+# Fail2Ban. Hence, you are required to add the following line in
+# "Extra options" under "Advanced settings" section at 
+# Services > SMB/CIFS > Settings :
+#
+# log level = 0 auth_json_audit:2@/var/log/samba/auth_json_audit.log
+#
+# you will also want to create a schedule task or cronjob to rotate
+# the log file periodically with root. The following line is an 
+# example, you may modify it according to your use scenario:
+#
+# cd /var/log/samba && touch auth_json_audit_2.log && touch auth_json_audit_1.log && rm auth_json_audit_2.log && mv auth_json_audit_1.log auth_json_audit_2.log && mv auth_json_audit.log auth_json_audit_1.log && touch auth_json_audit.log
+#
+
+
 [Definition]
+# we are only required to look for 2 message from samba which are:
+# - "NT_STATUS_WRONG_PASSWORD" which indicate a device attempt to 
+#    access Samba with correct ID but wrong password
+# - "NT_STATUS_NO_SUCH_USER" which indicate a device attempt to 
+#   access Samba with non-existence ID regardless of correct? or wrong password
+# and identify the remote address then ban according to jail setting
+
 failregex = status": "(NT_STATUS_WRONG_PASSWORD|NT_STATUS_NO_SUCH_USER).*remoteAddress": "ipv4:<HOST>:

--- a/etc/fail2ban/filter.d/samba.conf
+++ b/etc/fail2ban/filter.d/samba.conf
@@ -1,0 +1,2 @@
+[Definition]
+failregex = status": "(NT_STATUS_WRONG_PASSWORD|NT_STATUS_NO_SUCH_USER).*remoteAddress": "ipv4:<HOST>:

--- a/etc/fail2ban/filter.d/samba.conf
+++ b/etc/fail2ban/filter.d/samba.conf
@@ -12,15 +12,10 @@
 # "Extra options" under "Advanced settings" section at 
 # Services > SMB/CIFS > Settings :
 #
-# log level = 0 auth_json_audit:2@/var/log/samba/auth_json_audit.log
+# log level = 0 auth_json_audit:2@/var/log/samba/log.smbd
 #
-# you will also want to create a schedule task or cronjob to rotate
-# the log file periodically with root. The following line is an 
-# example, you may modify it according to your use scenario:
-#
-# cd /var/log/samba && touch auth_json_audit_2.log && touch auth_json_audit_1.log && rm auth_json_audit_2.log && mv auth_json_audit_1.log auth_json_audit_2.log && mv auth_json_audit.log auth_json_audit_1.log && touch auth_json_audit.log
-#
-
+# above option will instruct samba to log any authorization 
+# failure activities only into the file log.smbd
 
 [Definition]
 # we are only required to look for 2 message from samba which are:

--- a/etc/fail2ban/filter.d/samba.conf
+++ b/etc/fail2ban/filter.d/samba.conf
@@ -27,7 +27,7 @@
 # - "NT_STATUS_WRONG_PASSWORD" which indicate a device attempt to 
 #    access Samba with correct ID but wrong password
 # - "NT_STATUS_NO_SUCH_USER" which indicate a device attempt to 
-#   access Samba with non-existence ID regardless of correct? or wrong password
-# and identify the remote address then ban according to jail setting
+#   access Samba with non-existence ID, irrespective of the password provided.
+# Then F2B identify the remote address then ban according to jail setting
 
 failregex = status": "(NT_STATUS_WRONG_PASSWORD|NT_STATUS_NO_SUCH_USER).*remoteAddress": "ipv4:<HOST>:

--- a/usr/share/openmediavault/confdb/create.d/conf.service.fail2ban.sh
+++ b/usr/share/openmediavault/confdb/create.d/conf.service.fail2ban.sh
@@ -118,7 +118,7 @@ if ! omv_config_exists "${SERVICE_XPATH}/jails/jail[uuid='6f0cb653-d022-4edb-b68
     object="${object}<maxretry>3</maxretry>"
     object="${object}<bantime>-1</bantime>"
     object="${object}<filter>samba</filter>"
-    object="${object}<logpath>/var/log/samba/auth_json_audit.log</logpath>"
+    object="${object}<logpath>/var/log/samba/log.smbd</logpath>"
 # logpath depends on the samba's extra option as documented in samba filter file
     omv_config_add_node_data "${SERVICE_XPATH}/jails" "jail" "${object}"
 fi

--- a/usr/share/openmediavault/confdb/create.d/conf.service.fail2ban.sh
+++ b/usr/share/openmediavault/confdb/create.d/conf.service.fail2ban.sh
@@ -110,4 +110,17 @@ if ! omv_config_exists "${SERVICE_XPATH}/jails/jail[uuid='5f2b2d25-726c-5dc8-ac0
     omv_config_add_node_data "${SERVICE_XPATH}/jails" "jail" "${object}"
 fi
 
+if ! omv_config_exists "${SERVICE_XPATH}/jails/jail[uuid='6f0cb653-d022-4edb-b68b-a8be4fe2e484']"; then
+    object="<uuid>6f0cb653-d022-4edb-b68b-a8be4fe2e484</uuid>"
+    object="${object}<enable>0</enable>"
+    object="${object}<name>samba</name>"
+    object="${object}<port>139,445</port>"
+    object="${object}<maxretry>3</maxretry>"
+    object="${object}<bantime>-1</bantime>"
+    object="${object}<filter>samba</filter>"
+    object="${object}<logpath>/var/log/samba/auth_json_audit.log</logpath>"
+# logpath depends on the samba's extra option as documented in samba filter file
+    omv_config_add_node_data "${SERVICE_XPATH}/jails" "jail" "${object}"
+fi
+
 exit 0


### PR DESCRIPTION
in order for F2B to monitor SMB connection, the following must be added into SMB's extra options:

log level = 1 auth_json_audit:3@/var/log/samba/auth_json_audit.log

Also, due to the fact that log size will increase over time, it is advisable to rotate the log as required with schedule task or cronjob on biweekly or monthly basis. The following is the command i used to rotate log in my setup, but please feel free to improve it as needed:

cd /var/log/samba && touch auth_json_audit_3.log && touch auth_json_audit_2.log && touch auth_json_audit_1.log && rm auth_json_audit_3.log && mv auth_json_audit_2.log auth_json_audit_3.log && mv auth_json_audit_1.log auth_json_audit_2.log && mv auth_json_audit.log auth_json_audit_1.log && touch auth_json_audit.log

jail rules to use is as follows:
[SMB]
enabled = yes
port = 139,445
filter = samba
logpath = /var/log/samba/auth_json_audit.log
bantime = 86400 (adjust to your preference)
maxretry = 5 (adjust to your preference)